### PR TITLE
StorageClass support for jupyter web app

### DIFF
--- a/components/jupyter-web-app/frontend/src/app/resource-form/volume/volume.component.html
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/volume/volume.component.html
@@ -34,4 +34,10 @@
     <mat-label>Mount Point</mat-label>
     <input matInput formControlName="path" />
   </mat-form-field>
+
+  <!-- Storage ClassName -->
+  <mat-form-field appearance="outline" id="storage">
+    <mat-label>Storage Class name</mat-label>
+    <input matInput formControlName="class" />
+  </mat-form-field>
 </div>

--- a/components/jupyter-web-app/frontend/src/app/resource-form/volume/volume.component.scss
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/volume/volume.component.scss
@@ -1,21 +1,28 @@
+/** Modified other input percentage to fit storage class input**/
 #type {
-  max-width: 15%;
-}
-
-#size {
   max-width: 10%;
 }
 
+#size {
+  max-width: 7%;
+}
+
 #mode {
-  max-width: 20%;
+  max-width: 10%;
 }
 
 #name {
-  max-width: 30%;
+  max-width: 20%;
 }
 
 #path {
-  max-width: 25%;
+  max-width: 20%;
+}
+
+/** Added for storage class input**/
+
+#class {
+  max-width: 20%;
 }
 
 .volume-wrapper {


### PR DESCRIPTION
**Need**
Currently, there is no option to specify storage class to the attached volumes(PVC) in kubeflow Jupyter notebooks.
Whenever a notebook is launched, the default storage class is automatically selected.
Different use cases require different storage classes. Hence the need for storage class support

**Benefits**
Kubeflow users will be able to specify the storage class while launching Notebooks based on their use cases rather than the default option.
<img width="899" alt="Capture" src="https://user-images.githubusercontent.com/13795748/90609131-39382380-e221-11ea-9b24-57333d32774d.PNG">

This will enhance the adoption of kubeflow in the Machine Learning community for developing and deploying their end-to-end Machine Learning use cases.