### PR TITLE
fix for kubeflow 5299 git issue

### DIFF
--- a/components/notebook-controller/pkg/metrics/metrics.go
+++ b/components/notebook-controller/pkg/metrics/metrics.go
@@ -68,6 +68,8 @@ func (m *Metrics) Describe(ch chan<- *prometheus.Desc) {
 	m.runningNotebooks.Describe(ch)
 	m.NotebookCreation.Describe(ch)
 	m.NotebookFailCreation.Describe(ch)
+        m.NotebookCullingCount.Describe(ch)
+        m.NotebookCullingTimestamp.Describe(ch)
 }
 
 // Collect implements the prometheus.Collector interface.
@@ -76,6 +78,8 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 	m.runningNotebooks.Collect(ch)
 	m.NotebookCreation.Collect(ch)
 	m.NotebookFailCreation.Collect(ch)
+        m.NotebookCullingCount.Collect(ch)
+        m.NotebookCullingTimestamp.Collect(ch)
 }
 
 // scrape gets current running notebook statefulsets.


### PR DESCRIPTION
fix for issues-5299 . 

Installed kubeflow with manifest v1.0.2
enabled culling related environmental variables in notebook controller deployment .

ENABLE_CULLING:  true
      IDLE_TIME:       3
      USE_ISTIO:       true
      ISTIO_GATEWAY:   kubeflow/kubeflow-gateway
      POD_LABELS:      gcp-cred-secret=user-gcp-sa,gcp-cred-secret-filename=user-gcp-sa.json
created notebook server . The notebook server was idle for 3mins as expected the notebook server pod was terminated .
checked the metrics exposed by notebook controller by doing curl to http://:8080/metrics. didn't find any record with notebook_culling_total, last_notebook_culling_timestamp_seconds

find the notebook object events below :

Name:         testculling
```
Namespace:    hkumara
Labels:       app=testculling
Annotations:  kubeflow-resource-stopped: 2020-09-10T06:08:28Z
API Version:  kubeflow.org/v1
Kind:         Notebook
Metadata:
  Creation Timestamp:  2020-09-10T06:04:17Z
  Generation:          2
  Resource Version:    95548
  Self Link:           /apis/kubeflow.org/v1/namespaces/hkumara/notebooks/testculling
  UID:                 6831c404-1325-47a1-9fcf-b5613b36cfa3
Spec:
  Template:
    Spec:
      Containers:
        Image:              advanced-pykernel:latest
        Image Pull Policy:  IfNotPresent
        Name:               testculling
        Ports:
          Container Port:  8888
          Name:            notebook-port
          Protocol:        TCP
        Resources:
          Limits:
            Cpu:     500m
            Memory:  1Gi
          Requests:
            Cpu:                     500m
            Memory:                  1Gi
        Termination Message Path:    /dev/termination-log
        Termination Message Policy:  File
        Volume Mounts:
          Mount Path:        /home/cjup
          Name:              workspace-testculling
          Mount Path:        /home/jovyan/data-vol-1
          Name:              testculling-vol-1
          Mount Path:        /dev/shm
          Name:              dshm
        Working Dir:         /home/cjup
      Service Account Name:  default-editor
      Volumes:
        Name:  workspace-testculling
        Persistent Volume Claim:
          Claim Name:  workspace-testculling
        Name:          testculling-vol-1
        Persistent Volume Claim:
          Claim Name:  testculling-vol-1
        Empty Dir:
          Medium:  Memory
        Name:      dshm
Status:
  Conditions:
    Last Probe Time:  2020-09-10T06:04:38Z
    Type:             Running
    Last Probe Time:  2020-09-10T06:04:28Z
    Reason:           ContainerCreating
    Type:             Waiting
  Container State:
    Running:
      Started At:  2020-09-10T06:04:30Z
  Ready Replicas:  1
Events:
  Type     Reason                  Age    From                 Message
  ----     ------                  ----   ----                 -------
  Normal   SuccessfulCreate        4m32s  notebook-controller  Reissued from statefulset/testculling: create Pod testculling-0 in StatefulSet testculling successful
  Warning  FailedScheduling        4m32s  notebook-controller  Reissued from pod/testculling-0: error while running "VolumeBinding" filter plugin for pod "testculling-0": pod has unbound immediate PersistentVolumeClaims
  Normal   Scheduled               4m32s  notebook-controller  Reissued from pod/testculling-0: Successfully assigned hkumara/testculling-0 to bcmt-vm-cnfi-3784-control-01
  Normal   SuccessfulAttachVolume  4m32s  notebook-controller  Reissued from pod/testculling-0: AttachVolume.Attach succeeded for volume "pvc-f37c09f5-ac1c-44ed-8cfe-a6cb038a5e24"
  Normal   SuccessfulAttachVolume  4m32s  notebook-controller  Reissued from pod/testculling-0: AttachVolume.Attach succeeded for volume "pvc-91bcac0f-6306-4643-b377-67736f6734dc"
  Normal   Pulled                  4m22s  notebook-controller  Reissued from pod/testculling-0: Container image "advanced-pykernel:latest" already present on machine
  Normal   Created                 4m22s  notebook-controller  Reissued from pod/testculling-0: Created container testculling
  Normal   Started                 4m22s  notebook-controller  Reissued from pod/testculling-0: Started container testculling
  Normal   Killing                 31s    notebook-controller  Reissued from pod/testculling-0: Stopping container testculling
  Normal   SuccessfulDelete        31s    notebook-controller  Reissued from statefulset/testculling: delete Pod testculling-0 in 
```StatefulSet testculling successful
What did you expect to happen:

expect notebook_culling_total, last_notebook_culling_timestamp_seconds metrics records in metrics

